### PR TITLE
refactor: ArgumentResolver를 사용해서 회원 정보를 가져오는 방식으로 변경한다 

### DIFF
--- a/backend/src/main/java/com/cafein/backend/api/home/controller/HomeController.java
+++ b/backend/src/main/java/com/cafein/backend/api/home/controller/HomeController.java
@@ -3,6 +3,8 @@ package com.cafein.backend.api.home.controller;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.validation.Valid;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -17,9 +19,13 @@ import com.cafein.backend.api.home.dto.HomeDTO;
 import com.cafein.backend.domain.cafe.service.CafeService;
 import com.cafein.backend.domain.member.entity.Member;
 import com.cafein.backend.domain.member.service.MemberService;
+import com.cafein.backend.global.resolver.MemberInfo;
+import com.cafein.backend.global.resolver.MemberInfoDTO;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -31,8 +37,9 @@ public class HomeController {
 	private final MemberService memberService;
 
 	@GetMapping("/home")
-	public ResponseEntity<HomeDTO.Response> home(@RequestBody HomeDTO.Request homeRequestDTO) {
-		Member findMember = memberService.getMemberByEmail(homeRequestDTO.getMemberEmail());
+	public ResponseEntity<HomeDTO.Response> home(final @Valid @RequestBody HomeDTO.Request homeRequestDTO,
+												 @MemberInfo MemberInfoDTO memberInfoDTO) {
+		Member findMember = memberService.findMemberByMemberId(memberInfoDTO.getMemberId());
 
 		Pageable pageable = PageRequest.of(
 			Integer.parseInt(homeRequestDTO.getPageNo()),

--- a/backend/src/main/java/com/cafein/backend/api/home/dto/HomeDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/home/dto/HomeDTO.java
@@ -2,6 +2,9 @@ package com.cafein.backend.api.home.dto;
 
 import java.util.List;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,9 +18,16 @@ public class HomeDTO {
 	@AllArgsConstructor
 	public static class Request {
 
+		@NotNull
 		private String local;
+
+		@NotNull
 		private String pageNo;
+
+		@NotNull
 		private String sortBy;
+
+		@Email
 		private String memberEmail;
 	}
 

--- a/backend/src/main/java/com/cafein/backend/api/member/controller/MemberInfoController.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/controller/MemberInfoController.java
@@ -2,15 +2,14 @@ package com.cafein.backend.api.member.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.cafein.backend.api.member.dto.MemberInfoResponseDTO;
 import com.cafein.backend.api.member.service.MemberInfoService;
-import com.cafein.backend.global.jwt.service.TokenManager;
+import com.cafein.backend.global.resolver.MemberInfo;
+import com.cafein.backend.global.resolver.MemberInfoDTO;
 
-import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -24,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 public class MemberInfoController {
 
 	private final MemberInfoService memberInfoService;
-	private final TokenManager tokenManager;
 
 	@Tag(name = "member")
 	@Operation(summary = "회원 정보 조회 API", description = "회원 정보 조회 API")
@@ -34,12 +32,8 @@ public class MemberInfoController {
 		@ApiResponse(responseCode = "M-003", description = "해당 회원은 존재하지 않습니다.")
 	})
 	@GetMapping("/info")
-	public ResponseEntity<MemberInfoResponseDTO> getMemberInfo(
-		@RequestHeader("Authorization") String authorizationHeader) {
-
-		String accessToken = authorizationHeader.split(" ")[1];
-		Claims tokenClaims = tokenManager.getTokenClaims(accessToken);
-		Long memberId = Long.valueOf((Integer)tokenClaims.get("memberId"));
+	public ResponseEntity<MemberInfoResponseDTO> getMemberInfo(@MemberInfo MemberInfoDTO memberInfoDTO) {
+		Long memberId = memberInfoDTO.getMemberId();
 		MemberInfoResponseDTO memberInfoResponseDTO = memberInfoService.getMemberInfo(memberId);
 
 		return ResponseEntity.ok(memberInfoResponseDTO);

--- a/backend/src/main/java/com/cafein/backend/domain/member/constant/Role.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/constant/Role.java
@@ -3,4 +3,8 @@ package com.cafein.backend.domain.member.constant;
 public enum Role {
 
 	USER, ADMIN;
+
+	public static Role from(final String role) {
+		return Role.valueOf(role);
+	}
 }

--- a/backend/src/main/java/com/cafein/backend/global/config/web/WebConfig.java
+++ b/backend/src/main/java/com/cafein/backend/global/config/web/WebConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.cafein.backend.global.interceptor.AuthenticationInterceptor;
+import com.cafein.backend.global.resolver.MemberInfoArgumentResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import com.navercorp.lucy.security.xss.servletfilter.XssEscapeServletFilter;
 public class WebConfig implements WebMvcConfigurer {
 
 	private final AuthenticationInterceptor authenticationInterceptor;
+	private final MemberInfoArgumentResolver memberInfoArgumentResolver;
 	private final ObjectMapper objectMapper;
 
 	@Override
@@ -50,6 +52,11 @@ public class WebConfig implements WebMvcConfigurer {
 			.excludePathPatterns("/api/oauth/login",
 				"/api/access-token/issue",
 				"/api/logout");
+	}
+
+	@Override
+	public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(memberInfoArgumentResolver);
 	}
 
 	@Bean

--- a/backend/src/main/java/com/cafein/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/cafein/backend/global/error/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
 	NOT_ACCESS_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "A-007", "해당 토큰은 Access Token이 아닙니다."),
 
 	//회원
-	INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "M-001", "잘못된 회원 타입 입니다. (memberType : Kakao"),
+	INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "M-001", "잘못된 회원 타입 입니다. (memberType : Kakao)"),
 	ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "M-002", "이미 가입된 회원입니다."),
 	MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M-003", "해당 회원은 존재하지 않습니다.")
 	;

--- a/backend/src/main/java/com/cafein/backend/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/cafein/backend/global/error/GlobalExceptionHandler.java
@@ -1,14 +1,17 @@
 package com.cafein.backend.global.error;
 
-import com.cafein.backend.global.error.exception.BusinessException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import com.cafein.backend.global.error.exception.BusinessException;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -21,8 +24,17 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
         log.error("handleBindException", e);
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getBindingResult());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * HTTP 요청 본문의 내용을 읽을 수 없을 때 발생
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("handleBindException", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     /**
@@ -32,8 +44,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.error("handleMethodArgumentTypeMismatchException", e);
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     /**
@@ -53,8 +64,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleConflict(BusinessException e) {
         log.error("BusinessException", e);
         ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().getErrorCode(), e.getMessage());
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
-                .body(errorResponse);
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
     }
 
     /**

--- a/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfo.java
+++ b/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfo.java
@@ -1,0 +1,11 @@
+package com.cafein.backend.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberInfo {
+}

--- a/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfoArgumentResolver.java
+++ b/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfoArgumentResolver.java
@@ -1,0 +1,54 @@
+package com.cafein.backend.global.resolver;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.cafein.backend.domain.member.constant.Role;
+import com.cafein.backend.global.jwt.service.TokenManager;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberInfoArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final TokenManager tokenManager;
+
+	/**
+	 * 주어진 메소드의 파라미터가 이 ArgumentResolver 에서 지원하는 타입인지 검사한다
+	 * @return true 지원하는 타입 false 지원하지 않는 타입
+	 */
+	@Override
+	public boolean supportsParameter(final MethodParameter parameter) {
+		return parameter.getParameterType().equals(MemberInfoDTO.class)
+			&& parameter.hasParameterAnnotation(MemberInfo.class);
+	}
+
+	/**
+	 * 이 메소드의 반환값이 대상이 되는 메소드의 파라미터에 바인딩된다.
+	 * @return MemberInfoDTO
+	 */
+	@Override
+	public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+		final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		String authorizationHeader = request.getHeader("Authorization");
+		String accessToken = authorizationHeader.split(" ")[1];
+
+		Claims tokenClaims = tokenManager.getTokenClaims(accessToken);
+		Long memberId = Long.valueOf((Integer)tokenClaims.get("memberId"));
+		String role = (String) tokenClaims.get("role");
+
+		return MemberInfoDTO.builder()
+			.memberId(memberId)
+			.role(Role.from(role))
+			.build();
+	}
+}

--- a/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfoDTO.java
+++ b/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfoDTO.java
@@ -2,10 +2,15 @@ package com.cafein.backend.global.resolver;
 
 import com.cafein.backend.domain.member.constant.Role;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Builder @Getter
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MemberInfoDTO {
 
 	private Long memberId;

--- a/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfoDTO.java
+++ b/backend/src/main/java/com/cafein/backend/global/resolver/MemberInfoDTO.java
@@ -1,0 +1,13 @@
+package com.cafein.backend.global.resolver;
+
+import com.cafein.backend.domain.member.constant.Role;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder @Getter
+public class MemberInfoDTO {
+
+	private Long memberId;
+	private Role role;
+}


### PR DESCRIPTION
## 변경 내용

memberInfo를 편리하게 조회할 수 있도록 memberInfoArgumentResolver를 도입했습니다.
/api/home 을 조회할 때 Request Body가 없다면 400 Bad Request를 반환하도록 변경했습니다.

## 이슈 링크

#32 

## 참고자료
https://hudi.blog/spring-argument-resolver/
https://jyami.tistory.com/55




