### PR TITLE
test: 회원 정보 조회 Controller Layer Unit Test 작성

### DIFF
--- a/backend/src/test/java/com/cafein/backend/api/ControllerTestSupporter.java
+++ b/backend/src/test/java/com/cafein/backend/api/ControllerTestSupporter.java
@@ -1,5 +1,9 @@
 package com.cafein.backend.api;
 
+import static com.cafein.backend.support.fixture.MemberFixture.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -21,6 +25,7 @@ import com.cafein.backend.external.oauth.kakao.service.KakaoLoginApiServiceImpl;
 import com.cafein.backend.external.oauth.service.SocialLoginApiServiceFactory;
 import com.cafein.backend.global.interceptor.AuthenticationInterceptor;
 import com.cafein.backend.global.jwt.service.TokenManager;
+import com.cafein.backend.global.resolver.MemberInfoArgumentResolver;
 import com.cafein.backend.web.googletoken.client.GoogleTokenClient;
 import com.cafein.backend.web.kakaotoken.client.KakaoTokenClient;
 
@@ -28,6 +33,24 @@ import com.cafein.backend.web.kakaotoken.client.KakaoTokenClient;
 public class ControllerTestSupporter {
 
 	protected MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp(final WebApplicationContext context) throws Exception {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.alwaysDo(MockMvcResultHandlers.print())
+			.build();
+
+		// 테스트를 위해 인터셉터 bypass
+		given(authenticationInterceptor.preHandle(any(), any(), any()))
+			.willReturn(true);
+
+		// MemberInfoArgumentResolver 테스트를 위한 설정
+		given(memberInfoArgumentResolver.supportsParameter(any()))
+			.willReturn(true);
+
+		given(memberInfoArgumentResolver.resolveArgument(any(), any(), any(), any()))
+			.willReturn(memberInfoDTO());
+	}
 
 	@MockBean
 	protected OAuthLoginService oAuthLoginService;
@@ -69,15 +92,11 @@ public class ControllerTestSupporter {
 	protected SocialLoginApiServiceFactory socialLoginApiServiceFactory;
 
 	@MockBean
+	protected MemberInfoArgumentResolver memberInfoArgumentResolver;
+
+	@MockBean
 	protected GoogleTokenClient googleTokenClient;
 
 	@MockBean
 	protected KakaoTokenClient kakaoTokenClient;
-
-	@BeforeEach
-	void setUp(final WebApplicationContext context) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-			.alwaysDo(MockMvcResultHandlers.print())
-			.build();
-	}
 }

--- a/backend/src/test/java/com/cafein/backend/api/MemberInfoControllerTest.java
+++ b/backend/src/test/java/com/cafein/backend/api/MemberInfoControllerTest.java
@@ -1,0 +1,28 @@
+package com.cafein.backend.api;
+
+import static com.cafein.backend.support.fixture.LoginFixture.*;
+import static com.cafein.backend.support.fixture.MemberFixture.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+class MemberInfoControllerTest extends ControllerTestSupporter {
+
+	@Test
+	void 회원_정보를_가져온다() throws Exception {
+		given(memberInfoService.getMemberInfo(any()))
+			.willReturn(memberInfoResponseDTO());
+
+		mockMvc.perform(get("/api/member/info")
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_ACCESS)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.memberId").value(1))
+			.andExpect(jsonPath("$.email").value("test@test.com"));
+	}
+}

--- a/backend/src/test/java/com/cafein/backend/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/cafein/backend/support/fixture/MemberFixture.java
@@ -1,0 +1,46 @@
+package com.cafein.backend.support.fixture;
+
+import com.cafein.backend.api.member.dto.MemberInfoResponseDTO;
+import com.cafein.backend.domain.member.constant.MemberType;
+import com.cafein.backend.domain.member.constant.Role;
+import com.cafein.backend.domain.member.entity.Member;
+import com.cafein.backend.global.resolver.MemberInfoDTO;
+
+public class MemberFixture {
+
+	public static String member = "{\"memberId\" : \"1L\", \"role\" : \"ADMIN\"}";
+
+	public static Member createMember() {
+		return Member.builder()
+			.memberType(MemberType.KAKAO)
+			.name("홍길동")
+			.email("test@test.com")
+			.profile("http://k.kakaocdn.net/img_110x110.jpg")
+			.build();
+	}
+
+	public static MemberInfoDTO memberInfoDTO() {
+		return createMemberInfoDTO();
+	}
+
+	private static MemberInfoDTO createMemberInfoDTO() {
+		return MemberInfoDTO.builder()
+			.memberId(1L)
+			.role(Role.USER)
+			.build();
+	}
+
+	public static MemberInfoResponseDTO memberInfoResponseDTO() {
+		return createMemberInfoResponse();
+	}
+
+	private static MemberInfoResponseDTO createMemberInfoResponse() {
+		return MemberInfoResponseDTO.builder()
+			.memberId(1L)
+			.memberName("홍길동")
+			.email("test@test.com")
+			.profile("http://k.kakaocdn.net/img_110x110.jpg")
+			.role(Role.USER)
+			.build();
+	}
+}


### PR DESCRIPTION
## 변경 내용

access token으로 회원 정보 조회하는 컨트롤러 테스트

## 이슈 링크

#41 

## 변경된 동작

테스트 시 인터셉터를 bypass하기 위한 설정을 추가했습니다
MemberInfoArgumentResolver의 기본 동작을 mocking했습니다

## 체크리스트

- [X] 코드가 모든 유닛 테스트를 통과했습니다.
- [X] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
