### PR TITLE
test: 회원 도메인 로직 테스트를 구현한다

### DIFF
--- a/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
@@ -45,7 +45,7 @@ public class CafeController {
 	public ResponseEntity<CafeInfoDTO> cafeCongestionCheck(@PathVariable Long cafeId,
 								           		           @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
 		log.debug("memberId = {}", memberInfoDTO.getMemberId());
-		memberService.updateCoffeeBean(memberInfoDTO.getMemberId());
+		memberService.subtractCoffeeBean(memberInfoDTO.getMemberId());
 		viewedCafeService.addViewedCafe(memberService.findMemberByMemberId(memberInfoDTO.getMemberId()), cafeId);
 		return ResponseEntity.ok(cafeService.findCafeInfoById(memberInfoDTO.getMemberId(), cafeId));
 	}

--- a/backend/src/main/java/com/cafein/backend/api/home/controller/HomeController.java
+++ b/backend/src/main/java/com/cafein/backend/api/home/controller/HomeController.java
@@ -1,10 +1,7 @@
 package com.cafein.backend.api.home.controller;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,11 +9,8 @@ import com.cafein.backend.api.home.dto.HomeResponseDTO;
 import com.cafein.backend.domain.cafe.service.CafeService;
 import com.cafein.backend.global.resolver.MemberInfo;
 import com.cafein.backend.global.resolver.MemberInfoDTO;
-import com.cafein.backend.global.util.AuthorizationHeaderUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/java/com/cafein/backend/api/home/dto/HomeProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/home/dto/HomeProjection.java
@@ -34,4 +34,6 @@ public interface HomeProjection {
 
 	@Schema(description = "경도", example = "127.043297", required = true)
 	String getLongitude();
+
+	void setName(String name);
 }

--- a/backend/src/main/java/com/cafein/backend/api/home/dto/HomeProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/home/dto/HomeProjection.java
@@ -17,7 +17,7 @@ public interface HomeProjection {
 	@Schema(description = "카페 주소", example = "서울시 성동구 서울숲2길44-13 1층", required = true)
 	String getAddress();
 
-	@Schema(description = "카페 리뷰 갯수", example = "10", required = true)
+	@Schema(description = "카페 리뷰 개수", example = "10", required = true)
 	String getCommentReviewCount();
 
 	@Schema(description = "영업 상태", example = "영업중", required = true)

--- a/backend/src/main/java/com/cafein/backend/api/member/controller/MemberController.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/controller/MemberController.java
@@ -1,20 +1,14 @@
 package com.cafein.backend.api.member.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.cafein.backend.api.member.dto.CafeInfoViewedByMemberProjection;
 import com.cafein.backend.api.member.dto.MemberInfoResponseDTO;
 import com.cafein.backend.api.member.dto.MyPageDTO;
 import com.cafein.backend.api.member.service.MemberInfoService;
 import com.cafein.backend.api.member.service.MyPageService;
-import com.cafein.backend.domain.cafe.entity.Cafe;
-import com.cafein.backend.domain.cafe.service.CafeService;
-import com.cafein.backend.domain.viewedcafe.service.ViewedCafeService;
 import com.cafein.backend.global.resolver.MemberInfo;
 import com.cafein.backend.global.resolver.MemberInfoDTO;
 
@@ -50,6 +44,13 @@ public class MemberController {
 		return ResponseEntity.ok(memberInfoResponseDTO);
 	}
 
+	@Tag(name = "member")
+	@Operation(summary = "마이페이지 조회 API", description = "마이페이지 조회 API")
+	@ApiResponses({
+		@ApiResponse(responseCode = "A-001", description = "토큰이 만료되었습니다."),
+		@ApiResponse(responseCode = "A-002", description = "해당 토큰은 유효한 토큰이 아닙니다."),
+		@ApiResponse(responseCode = "M-003", description = "해당 회원은 존재하지 않습니다.")
+	})
 	@GetMapping("/mypage")
 	public ResponseEntity<MyPageDTO> getMyPage(@ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
 		return ResponseEntity.ok(myPageService.getMyPageDTO(memberInfoDTO.getMemberId()));

--- a/backend/src/main/java/com/cafein/backend/api/member/dto/CafeInfoViewedByMemberProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/dto/CafeInfoViewedByMemberProjection.java
@@ -1,8 +1,15 @@
 package com.cafein.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public interface CafeInfoViewedByMemberProjection {
 
+	@Schema(description = "카페 이름", example = "5to7", required = true)
 	String getCafeName();
+
+	@Schema(description = "카페 주소", example = "서울시 성동구 서울숲2길44-13 1층", required = true)
 	String getAddress();
+
+	@Schema(description = "카페 리뷰 개수", example = "10", required = true)
 	String getCommentReviewCount();
 }

--- a/backend/src/main/java/com/cafein/backend/api/member/dto/MemberInfoResponseDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/dto/MemberInfoResponseDTO.java
@@ -40,4 +40,16 @@ public class MemberInfoResponseDTO {
 			.viewedCafeIds(viewedCafeIds)
 			.build();
 	}
+
+	@Override
+	public String toString() {
+		return "MemberInfoResponseDTO{" +
+			"memberId=" + memberId +
+			", email='" + email + '\'' +
+			", memberName='" + memberName + '\'' +
+			", profile='" + profile + '\'' +
+			", role=" + role +
+			", viewedCafeIds=" + viewedCafeIds +
+			'}';
+	}
 }

--- a/backend/src/main/java/com/cafein/backend/api/member/dto/MemberReviewProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/dto/MemberReviewProjection.java
@@ -1,10 +1,21 @@
 package com.cafein.backend.api.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public interface MemberReviewProjection {
 
+	@Schema(description = "카페 이름", example = "5to7", required = true)
 	String getCafeName();
+
+	@Schema(description = "카페 주소", example = "서울시 성동구 서울숲2길44-13 1층", required = true)
 	String getAddress();
+
+	@Schema(description = "카페 혼잡도", example = "MEDIUM", required = true)
 	String getCafeCongestion();
+
+	@Schema(description = "카페가 청결한지에 대한 리뷰", example = "true", required = true)
 	String getIsClean();
+
+	@Schema(description = "카페에 플러그가 있는지에 대한 리뷰", example = "true", required = true)
 	String getHasPlug();
 }

--- a/backend/src/main/java/com/cafein/backend/api/member/dto/MyPageDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/dto/MyPageDTO.java
@@ -2,6 +2,7 @@ package com.cafein.backend.api.member.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,8 @@ public class MyPageDTO {
 
 	private List<CafeInfoViewedByMemberProjection> cafeInfoViewedByMemberDTOS;
 	private List<MemberReviewProjection> reviewDTOS;
+
+	@Schema(description = "총 리뷰 수", example = "10", required = true)
 	private long reviewCount;
 
 	public static MyPageDTO of(final List<CafeInfoViewedByMemberProjection> cafeInfoViewedByMemberDTOs,

--- a/backend/src/main/java/com/cafein/backend/api/member/dto/MyPageDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/dto/MyPageDTO.java
@@ -23,4 +23,13 @@ public class MyPageDTO {
 			.reviewCount(reviewCount)
 			.build();
 	}
+
+	@Override
+	public String toString() {
+		return "MyPageDTO{" +
+			"cafeInfoViewedByMemberDTOS=" + cafeInfoViewedByMemberDTOS +
+			", reviewDTOS=" + reviewDTOS +
+			", reviewCount=" + reviewCount +
+			'}';
+	}
 }

--- a/backend/src/main/java/com/cafein/backend/api/member/service/MemberInfoService.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/service/MemberInfoService.java
@@ -23,7 +23,7 @@ public class MemberInfoService {
 	@Transactional(readOnly = true)
 	public MemberInfoResponseDTO getMemberInfo(final Long memberId) {
 		Member member = memberService.findMemberByMemberId(memberId);
-		List<Long> viewdCafeIds = viewedCafeService.findViewedCafes(memberId);
-		return MemberInfoResponseDTO.of(member, viewdCafeIds);
+		List<Long> viewedCafeIds = viewedCafeService.findViewedCafes(memberId);
+		return MemberInfoResponseDTO.of(member, viewedCafeIds);
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
@@ -76,24 +76,17 @@ public class Member extends BaseTimeEntity {
 	private List<Comment> comments = new ArrayList<>();
 
 	@Builder
-	public Member(MemberType memberType, String email, String password, String name, String profile, Role role, Integer coffeeBean) {
+	public Member(final Long memberId, final MemberType memberType, final String email,
+		final String password, final String name, final String profile, final Integer coffeeBean,
+		final Role role, final String refreshToken, final LocalDateTime tokenExpirationTime) {
+		this.memberId = memberId;
 		this.memberType = memberType;
 		this.email = email;
 		this.password = password;
 		this.name = name;
 		this.profile = profile;
-		this.role = role;
 		this.coffeeBean = coffeeBean;
-	}
-
-	@Builder(builderMethodName = "testBuilder")
-	public Member(final Long memberId, final MemberType memberType, final String email,
-		final String name, final String profile, final String refreshToken, final LocalDateTime tokenExpirationTime) {
-		this.memberId = memberId;
-		this.memberType = memberType;
-		this.email = email;
-		this.name = name;
-		this.profile = profile;
+		this.role = role;
 		this.refreshToken = refreshToken;
 		this.tokenExpirationTime = tokenExpirationTime;
 	}

--- a/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
@@ -100,7 +100,7 @@ public class Member extends BaseTimeEntity {
 		this.tokenExpirationTime = now;
 	}
 
-	public void updateCoffeeBean(Integer coffeeBean) {
+	public void subtractCoffeeBean(Integer coffeeBean) {
 		this.coffeeBean = coffeeBean - 2;
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
@@ -63,6 +63,6 @@ public class MemberService {
 		if (member.getCoffeeBean() < 2) {
 			throw new BusinessException(ErrorCode.NOT_ENOUGH_COFFEE_BEAN);
 		}
-		member.updateCoffeeBean(member.getCoffeeBean());
+		member.subtractCoffeeBean(member.getCoffeeBean());
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
@@ -57,7 +57,7 @@ public class MemberService {
 	}
 
 	@Transactional
-	public void updateCoffeeBean(final Long memberId) {
+	public void subtractCoffeeBean(final Long memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST));
 		if (member.getCoffeeBean() < 2) {

--- a/backend/src/main/java/com/cafein/backend/global/config/DatabaseInitializer.java
+++ b/backend/src/main/java/com/cafein/backend/global/config/DatabaseInitializer.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 import javax.annotation.PostConstruct;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 @Profile({"dev"})
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.jpa.hibernate.ddl-auto", havingValue = "create")
 public class DatabaseInitializer {
 
 	private final InitService initService;

--- a/backend/src/test/java/com/cafein/backend/api/ControllerTestSupporter.java
+++ b/backend/src/test/java/com/cafein/backend/api/ControllerTestSupporter.java
@@ -17,9 +17,11 @@ import org.springframework.web.context.WebApplicationContext;
 import com.cafein.backend.api.login.service.OAuthLoginService;
 import com.cafein.backend.api.logout.service.LogoutService;
 import com.cafein.backend.api.member.service.MemberInfoService;
+import com.cafein.backend.api.member.service.MyPageService;
 import com.cafein.backend.api.token.service.TokenService;
 import com.cafein.backend.domain.cafe.service.CafeService;
 import com.cafein.backend.domain.member.service.MemberService;
+import com.cafein.backend.domain.viewedcafe.service.ViewedCafeService;
 import com.cafein.backend.external.oauth.google.service.GoogleLoginApiServiceImpl;
 import com.cafein.backend.external.oauth.kakao.service.KakaoLoginApiServiceImpl;
 import com.cafein.backend.external.oauth.service.SocialLoginApiServiceFactory;
@@ -73,6 +75,12 @@ public class ControllerTestSupporter {
 
 	@MockBean
 	protected CafeService cafeService;
+
+	@MockBean
+	protected ViewedCafeService viewedCafeService;
+
+	@MockBean
+	protected MyPageService myPageService;
 
 	@MockBean
 	protected GoogleLoginApiServiceImpl googleLoginApiServiceImpl;

--- a/backend/src/test/java/com/cafein/backend/api/ControllerTestSupporterV1.java
+++ b/backend/src/test/java/com/cafein/backend/api/ControllerTestSupporterV1.java
@@ -1,0 +1,17 @@
+package com.cafein.backend.api;
+
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.cafein.backend.global.error.GlobalExceptionHandler;
+
+public abstract class ControllerTestSupporterV1 {
+
+	protected MockMvc mockMvc(Object controller) {
+		return MockMvcBuilders.standaloneSetup(controller)
+			.setControllerAdvice(new GlobalExceptionHandler())
+			.alwaysDo(MockMvcResultHandlers.print())
+			.build();
+	}
+}

--- a/backend/src/test/java/com/cafein/backend/api/HomeControllerTest.java
+++ b/backend/src/test/java/com/cafein/backend/api/HomeControllerTest.java
@@ -1,43 +1,39 @@
 package com.cafein.backend.api;
 
-import static com.cafein.backend.support.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.cafein.backend.support.fixture.HomeFixture.*;
 import static org.mockito.BDDMockito.*;
-
-import java.util.Collections;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.cafein.backend.api.home.controller.HomeController;
 import com.cafein.backend.api.home.dto.HomeResponseDTO;
 import com.cafein.backend.domain.cafe.service.CafeService;
 
 @ExtendWith(MockitoExtension.class)
-class HomeControllerTest {
+class HomeControllerTest extends ControllerTestSupporterV1 {
 
 	@Mock
 	private CafeService cafeService;
 
-	@InjectMocks
-	private HomeController homeController;
-
 	@Test
-	void 홈_화면에_필요한_카페_정보를_반환한다() {
+	void 홈_화면에_필요한_카페_정보를_반환한다() throws Exception {
 		HomeResponseDTO response = HomeResponseDTO.builder()
 			.cafeCount(5L)
-			.cafes(Collections.emptyList())
+			.cafes(HOME_PROJECTION)
 			.build();
-		given(cafeService.getHomeData(anyLong())).willReturn(response);
 
-		final ResponseEntity<HomeResponseDTO> result = homeController.home(MEMBER_INFO_DTO);
+		given(cafeService.getHomeData(any())).willReturn(response);
 
-		then(cafeService).should(times(1)).getHomeData(anyLong());
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		mockMvc(new HomeController(cafeService))
+			.perform(MockMvcRequestBuilders
+				.get("/api/home"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.cafeCount").value(5L))
+			.andExpect(jsonPath("$.cafes[0].name").value("5to7"));
 	}
 }

--- a/backend/src/test/java/com/cafein/backend/api/HomeControllerTest.java
+++ b/backend/src/test/java/com/cafein/backend/api/HomeControllerTest.java
@@ -1,0 +1,43 @@
+package com.cafein.backend.api;
+
+import static com.cafein.backend.support.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.cafein.backend.api.home.controller.HomeController;
+import com.cafein.backend.api.home.dto.HomeResponseDTO;
+import com.cafein.backend.domain.cafe.service.CafeService;
+
+@ExtendWith(MockitoExtension.class)
+class HomeControllerTest {
+
+	@Mock
+	private CafeService cafeService;
+
+	@InjectMocks
+	private HomeController homeController;
+
+	@Test
+	void 홈_화면에_필요한_카페_정보를_반환한다() {
+		HomeResponseDTO response = HomeResponseDTO.builder()
+			.cafeCount(5L)
+			.cafes(Collections.emptyList())
+			.build();
+		given(cafeService.getHomeData(anyLong())).willReturn(response);
+
+		final ResponseEntity<HomeResponseDTO> result = homeController.home(MEMBER_INFO_DTO);
+
+		then(cafeService).should(times(1)).getHomeData(anyLong());
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+}

--- a/backend/src/test/java/com/cafein/backend/api/MemberControllerTest.java
+++ b/backend/src/test/java/com/cafein/backend/api/MemberControllerTest.java
@@ -1,28 +1,56 @@
 package com.cafein.backend.api;
 
-import static com.cafein.backend.support.fixture.LoginFixture.*;
 import static com.cafein.backend.support.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
-class MemberControllerTest extends ControllerTestSupporter {
+import com.cafein.backend.api.member.controller.MemberController;
+import com.cafein.backend.api.member.dto.MemberInfoResponseDTO;
+import com.cafein.backend.api.member.dto.MyPageDTO;
+import com.cafein.backend.api.member.service.MemberInfoService;
+import com.cafein.backend.api.member.service.MyPageService;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+
+	@Mock
+	private MemberInfoService memberInfoService;
+
+	@Mock
+	private MyPageService myPageService;
+
+	@InjectMocks
+	private MemberController memberController;
 
 	@Test
-	void 회원_정보를_가져온다() throws Exception {
+	void 회원_정보를_가져온다() {
 		given(memberInfoService.getMemberInfo(any()))
 			.willReturn(MEMBER_INFO_RESPONSE_DTO);
 
-		mockMvc.perform(get("/api/member/info")
-				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_ACCESS)
-			)
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.memberId").value(1))
-			.andExpect(jsonPath("$.email").value("test@test.com"));
+		final ResponseEntity<MemberInfoResponseDTO> result = memberController.getMemberInfo(MEMBER_INFO_DTO);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo(MEMBER_INFO_RESPONSE_DTO);
+	}
+
+	@Test
+	void 마이페이지에_사용하는_회원_정보를_반환한다() {
+		MyPageDTO response = MyPageDTO.builder()
+			.reviewCount(5L)
+			.build();
+		given(myPageService.getMyPageDTO(1L)).willReturn(response);
+
+		final ResponseEntity<MyPageDTO> result = memberController.getMyPage(MEMBER_INFO_DTO);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo(response);
 	}
 }

--- a/backend/src/test/java/com/cafein/backend/core/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/cafein/backend/core/member/domain/MemberTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
+import com.cafein.backend.domain.member.entity.Member;
 import com.cafein.backend.global.util.DateTimeUtils;
 
 class MemberTest {
@@ -26,5 +27,12 @@ class MemberTest {
 		MEMBER.expireRefreshToken(LocalDateTime.now());
 
 		assertThat(MEMBER.getTokenExpirationTime()).isBefore(LocalDateTime.now());
+	}
+
+	@Test
+	void 카페를_조회하면_커피콩을_차감한다() {
+		MEMBER.subtractCoffeeBean(MEMBER.getCoffeeBean());
+
+		assertThat(MEMBER.getCoffeeBean()).isEqualTo(98);
 	}
 }

--- a/backend/src/test/java/com/cafein/backend/service/CafeServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/CafeServiceTest.java
@@ -1,0 +1,34 @@
+package com.cafein.backend.service;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.cafein.backend.domain.cafe.repository.CafeRepository;
+import com.cafein.backend.domain.cafe.service.CafeService;
+import com.cafein.backend.support.utils.ServiceTest;
+
+@ServiceTest
+class CafeServiceTest {
+
+	@Autowired
+	private CafeService cafeService;
+
+	@MockBean
+	private CafeRepository cafeRepository;
+
+	@Test
+	void 홈_화면의_전체_카페_정보를_반환한다() {
+		given(cafeRepository.count()).willReturn(5L);
+		given(cafeRepository.getHomeData(1L)).willReturn(Collections.emptyList());
+
+		cafeService.getHomeData(1L);
+
+		then(cafeRepository).should(times(1)).count();
+		then(cafeRepository).should(times(1)).getHomeData(anyLong());
+	}
+}

--- a/backend/src/test/java/com/cafein/backend/service/MyPageServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/MyPageServiceTest.java
@@ -1,0 +1,40 @@
+package com.cafein.backend.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.cafein.backend.api.member.dto.MyPageDTO;
+import com.cafein.backend.api.member.service.MyPageService;
+import com.cafein.backend.domain.Review.respository.ReviewRepository;
+import com.cafein.backend.domain.cafe.service.CafeService;
+import com.cafein.backend.support.utils.ServiceTest;
+
+@ServiceTest
+class MyPageServiceTest {
+
+	@Autowired
+	private MyPageService myPageService;
+
+	@MockBean
+	private ReviewRepository reviewRepository;
+
+	@MockBean
+	private CafeService cafeService;
+
+	@Test
+	void 회원이_최근_본_매장과_작성한_게시물_정보를_반환한다() {
+		given(cafeService.findCafeInfoViewedByMember(any())).willReturn(Collections.emptyList());
+		given(reviewRepository.findReviewsByMemberId(anyLong())).willReturn(Collections.emptyList());
+		given(reviewRepository.countReviewByMemberId(anyLong())).willReturn(5L);
+
+		final MyPageDTO myPageDTO = myPageService.getMyPageDTO(1L);
+
+		assertThat(myPageDTO.getReviewCount()).isEqualTo(5L);
+	}
+}

--- a/backend/src/test/java/com/cafein/backend/support/fixture/HomeFixture.java
+++ b/backend/src/test/java/com/cafein/backend/support/fixture/HomeFixture.java
@@ -1,0 +1,20 @@
+package com.cafein.backend.support.fixture;
+
+import java.util.List;
+
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+
+import com.cafein.backend.api.home.dto.HomeProjection;
+
+public class HomeFixture {
+
+	public static List<HomeProjection> HOME_PROJECTION = createHomeProjection();
+
+	private static List<HomeProjection> createHomeProjection() {
+		HomeProjection projection = new SpelAwareProxyProjectionFactory().createProjection(HomeProjection.class);
+
+		projection.setName("5to7");
+
+		return List.of(projection);
+	}
+}

--- a/backend/src/test/java/com/cafein/backend/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/cafein/backend/support/fixture/MemberFixture.java
@@ -24,6 +24,7 @@ public class MemberFixture {
 			.name("황의찬")
 			.email("chan@test.com")
 			.profile("http://k.kakaocdn.net/img_110x110.jpg")
+			.coffeeBean(100)
 			.refreshToken(REFRESH_TOKEN)
 			.tokenExpirationTime(LocalDateTime.now().plusDays(14))
 			.build();
@@ -36,6 +37,7 @@ public class MemberFixture {
 			.name("황의찬")
 			.email("chan@test.com")
 			.profile("http://k.kakaocdn.net/img_110x110.jpg")
+			.coffeeBean(100)
 			.refreshToken(REFRESH_TOKEN)
 			.tokenExpirationTime(LocalDateTime.now().minusDays(1))
 			.build();

--- a/backend/src/test/java/com/cafein/backend/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/cafein/backend/support/fixture/MemberFixture.java
@@ -18,7 +18,7 @@ public class MemberFixture {
 	public static final MemberInfoResponseDTO MEMBER_INFO_RESPONSE_DTO = memberInfoResponseDTO();
 
 	private static Member createMember() {
-		return Member.testBuilder()
+		return Member.builder()
 			.memberId(1L)
 			.memberType(MemberType.KAKAO)
 			.name("황의찬")
@@ -30,7 +30,7 @@ public class MemberFixture {
 	}
 
 	private static Member createMemberWithExpiredRefreshToken() {
-		return Member.testBuilder()
+		return Member.builder()
 			.memberId(1L)
 			.memberType(MemberType.KAKAO)
 			.name("황의찬")


### PR DESCRIPTION
## 변경 내용
-  Member 도메인 로직 테스트
-  Home API 테스트, Member 정보를 반환하는 API 테스트
-  Home과 Member에서 사용하는 서비스 테스트
-  myPage Swagger annotation 적용

## 이슈 링크

#66 

## 특이 사항

DatabaseInitializer에 ddl-auto가 create일때만 실행하도록 `ConditionalOnProperty` 애노테이션을 추가했습니다.

## 체크리스트

- [x] 코드가 모든 유닛 테스트를 통과했습니다.
- [x] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
- [x] 변경사항에 대한 문서가 업데이트 되었습니다.
