### PR TITLE
댓글 API를 구현한다

### DIFF
--- a/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeInfoDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeInfoDTO.java
@@ -2,6 +2,8 @@ package com.cafein.backend.api.cafe.dto;
 
 import java.util.List;
 
+import com.cafein.backend.api.comment.dto.CommentInfoDTO;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,5 +14,5 @@ public class CafeInfoDTO {
 	private CafeInfoProjection cafeInfoProjection;
 
 	@Schema(name = "comment", description = "카페 리뷰", type = "array", example = "[여기 카페 너무 트렌디해요!, 사장님이 잘생겼어요!]", required = true)
-	private List<String> comments;
+	private List<CommentInfoDTO> comments;
 }

--- a/backend/src/main/java/com/cafein/backend/api/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/cafein/backend/api/comment/controller/CommentController.java
@@ -1,0 +1,46 @@
+package com.cafein.backend.api.comment.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.cafein.backend.api.comment.dto.CommentDTO;
+import com.cafein.backend.domain.comment.service.CommentService;
+import com.cafein.backend.global.resolver.MemberInfo;
+import com.cafein.backend.global.resolver.MemberInfoDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Tag(name = "cafe", description = "카페 관련 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@Tag(name = "cafe")
+	@Operation(summary = "카페 댓글 등록 API", description = "카페에 댓글을 추가하는 API 입니다. 키워드는 중복 선택이 가능합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "CO-001", description = "해당 키워드는 존재하지 않습니다.")
+	})
+	@PostMapping("/cafe/{cafeId}/comment")
+	public ResponseEntity<String> addComment(@Valid @RequestBody CommentDTO.Request requestDTO,
+										     @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO,
+										     @PathVariable Long cafeId) {
+		commentService.addComment(requestDTO, cafeId, memberInfoDTO.getMemberId());
+		return ResponseEntity.ok("comment added");
+	}
+}

--- a/backend/src/main/java/com/cafein/backend/api/comment/dto/CommentDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/comment/dto/CommentDTO.java
@@ -1,0 +1,23 @@
+package com.cafein.backend.api.comment.dto;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CommentDTO {
+
+	@Getter @Builder
+	public static class Request {
+
+		@Schema(name = "content", description = "댓글 내용", example = "여기 카페 너무 트렌디해요!", required = true)
+		@NotNull
+		private String content;
+
+		@Schema(name = "keywords", description = "댓글 키워드", example = "[청결도, 콘센트, 화장실, 메뉴, 좌석, 분위기]", required = false)
+		private List<String> keywords;
+	}
+}

--- a/backend/src/main/java/com/cafein/backend/api/comment/dto/CommentInfoDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/comment/dto/CommentInfoDTO.java
@@ -1,0 +1,26 @@
+package com.cafein.backend.api.comment.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.cafein.backend.domain.commentkeyword.entity.CommentKeyword;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @Builder
+public class CommentInfoDTO {
+
+	@Schema(name = "memberName", description = "회원 이름", example = "황의찬", required = true)
+	private String memberName;
+
+	@Schema(name = "createdTime", description = "댓글 등록 시간", example = "2023-06-27 17:42:08.671987", required = true)
+	private LocalDateTime createdTime;
+
+	@Schema(name = "content", description = "댓글 내용", example = "여기 카페 너무 트렌디해요!", required = true)
+	private String content;
+
+	@Schema(name = "keywords", description = "댓글 키워드", type = "array", example = "[청결도, 콘센트]", required = true)
+	private List<CommentKeyword> keywords;
+}

--- a/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
@@ -1,7 +1,6 @@
 package com.cafein.backend.domain.cafe.repository;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,8 +10,8 @@ import org.springframework.data.repository.query.Param;
 import com.cafein.backend.api.cafe.dto.CafeInfoProjection;
 import com.cafein.backend.api.home.dto.HomeProjection;
 import com.cafein.backend.api.member.dto.CafeInfoViewedByMemberProjection;
-import com.cafein.backend.domain.cafe.constant.Local;
 import com.cafein.backend.domain.cafe.entity.Cafe;
+import com.cafein.backend.domain.comment.entity.Comment;
 
 public interface CafeRepository extends JpaRepository<Cafe, Long> {
 

--- a/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
@@ -86,6 +86,9 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
 		"WHERE c.cafe_id = :cafeId", nativeQuery = true)
 	CafeInfoViewedByMemberProjection findCafeInfoViewedByMember(@Param("cafeId") Long cafeId);
 
+	@Query("SELECT co FROM Comment co WHERE co.cafe.cafeId = :cafeId")
+	List<Comment> findAllCommentByCafeId(@Param("cafeId") Long cafeId);
+
 	Optional<Cafe> findByName(String name);
 
 	long count();

--- a/backend/src/main/java/com/cafein/backend/domain/cafe/service/CafeService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/cafe/service/CafeService.java
@@ -9,7 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.cafein.backend.api.cafe.dto.CafeInfoDTO;
 import com.cafein.backend.api.home.dto.HomeResponseDTO;
 import com.cafein.backend.api.member.dto.CafeInfoViewedByMemberProjection;
+import com.cafein.backend.domain.cafe.entity.Cafe;
 import com.cafein.backend.domain.cafe.repository.CafeRepository;
+import com.cafein.backend.domain.comment.entity.Comment;
+import com.cafein.backend.global.error.ErrorCode;
+import com.cafein.backend.global.error.exception.EntityNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,7 +36,7 @@ public class CafeService {
 	public CafeInfoDTO findCafeInfoById(Long memberId, Long cafeId) {
 		return CafeInfoDTO.builder()
 			.cafeInfoProjection(cafeRepository.findCafeInfoById(memberId, cafeId))
-			.comments(cafeRepository.findCommentsByCafeId(cafeId))
+			.comments(getComments(cafeId))
 			.build();
 	}
 
@@ -41,5 +45,11 @@ public class CafeService {
 		return viewedCafeIds.stream()
 			.map(cafeRepository::findCafeInfoViewedByMember)
 			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public Cafe findCafeByCafeId(final Long cafeId) {
+		return cafeRepository.findById(cafeId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.CAFE_NOT_EXIST));
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/cafe/service/CafeService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/cafe/service/CafeService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cafein.backend.api.cafe.dto.CafeInfoDTO;
+import com.cafein.backend.api.comment.dto.CommentInfoDTO;
 import com.cafein.backend.api.home.dto.HomeResponseDTO;
 import com.cafein.backend.api.member.dto.CafeInfoViewedByMemberProjection;
 import com.cafein.backend.domain.cafe.entity.Cafe;
@@ -16,7 +17,9 @@ import com.cafein.backend.global.error.ErrorCode;
 import com.cafein.backend.global.error.exception.EntityNotFoundException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -38,6 +41,18 @@ public class CafeService {
 			.cafeInfoProjection(cafeRepository.findCafeInfoById(memberId, cafeId))
 			.comments(getComments(cafeId))
 			.build();
+	}
+
+	private List<CommentInfoDTO> getComments(final Long cafeId) {
+		final List<Comment> comments = cafeRepository.findAllCommentByCafeId(cafeId);
+		return comments.stream()
+			.map(comment -> CommentInfoDTO.builder()
+				.memberName(comment.getMember().getName())
+				.createdTime(comment.getCreatedTime())
+				.content(comment.getContent())
+				.keywords(comment.getKeywords())
+				.build())
+			.collect(Collectors.toList());
 	}
 
 	@Transactional(readOnly = true)

--- a/backend/src/main/java/com/cafein/backend/domain/comment/constant/Keyword.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/constant/Keyword.java
@@ -1,0 +1,20 @@
+package com.cafein.backend.domain.comment.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum Keyword {
+
+	CLEAN("청결도"),
+	PLUG("콘센트"),
+	RESTROOM("화장실"),
+	MENU("메뉴"),
+	SEAT("좌석"),
+	MOOD("분위기");
+
+	private final String keyWord;
+
+	Keyword(final String keyWord) {
+		this.keyWord = keyWord;
+	}
+}

--- a/backend/src/main/java/com/cafein/backend/domain/comment/constant/Keyword.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/constant/Keyword.java
@@ -1,5 +1,10 @@
 package com.cafein.backend.domain.comment.constant;
 
+import java.util.Arrays;
+
+import com.cafein.backend.global.error.ErrorCode;
+import com.cafein.backend.global.error.exception.BusinessException;
+
 import lombok.Getter;
 
 @Getter
@@ -16,5 +21,12 @@ public enum Keyword {
 
 	Keyword(final String keyWord) {
 		this.keyWord = keyWord;
+	}
+
+	public static Keyword from(String keyword) {
+		return Arrays.stream(Keyword.values())
+			.filter(value -> value.getKeyWord().equals(keyword))
+			.findFirst()
+			.orElseThrow(() -> new BusinessException(ErrorCode.KEYWORD_NOT_EXIST));
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/entity/Comment.java
@@ -2,6 +2,9 @@ package com.cafein.backend.domain.comment.entity;
 
 import static javax.persistence.FetchType.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -10,8 +13,10 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import com.cafein.backend.domain.cafe.entity.Cafe;
+import com.cafein.backend.domain.commentkeyword.entity.CommentKeyword;
 import com.cafein.backend.domain.common.BaseTimeEntity;
 import com.cafein.backend.domain.member.entity.Member;
 
@@ -33,6 +38,9 @@ public class Comment extends BaseTimeEntity {
 	@Lob
 	private String content;
 
+	@OneToMany(mappedBy = "comment")
+	List<CommentKeyword> keywords = new ArrayList<>();
+
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "cafe_id")
 	private Cafe cafe;
@@ -46,5 +54,16 @@ public class Comment extends BaseTimeEntity {
 		this.content = content;
 		this.cafe = cafe;
 		this.member = member;
+	}
+
+	@Override
+	public String toString() {
+		return "Comment{" +
+			"commentId=" + commentId +
+			", content='" + content + '\'' +
+			", keywords=" + keywords +
+			", cafe=" + cafe +
+			", member=" + member +
+			'}';
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/comment/entity/CommentKeyword.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/entity/CommentKeyword.java
@@ -1,0 +1,35 @@
+package com.cafein.backend.domain.comment.entity;
+
+import static javax.persistence.FetchType.*;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.cafein.backend.domain.comment.constant.Keyword;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentKeyword {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long commentKeywordId;
+
+	@Enumerated(EnumType.STRING)
+	private Keyword keyword;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "comment_id")
+	private Comment comment;
+}

--- a/backend/src/main/java/com/cafein/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,6 @@
 package com.cafein.backend.domain.comment.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.cafein.backend.domain.comment.entity.Comment;
 

--- a/backend/src/main/java/com/cafein/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/repository/CommentRepository.java
@@ -5,7 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.cafein.backend.domain.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-	@Query("SELECT COUNT(c) FROM Comment c WHERE c.cafe.cafeId = :cafeId")
-	Integer countCommentByCafeId(Long cafeId);
 }

--- a/backend/src/main/java/com/cafein/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/comment/service/CommentService.java
@@ -1,24 +1,56 @@
 package com.cafein.backend.domain.comment.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.cafein.backend.api.comment.dto.CommentDTO;
+import com.cafein.backend.domain.cafe.entity.Cafe;
+import com.cafein.backend.domain.cafe.service.CafeService;
+import com.cafein.backend.domain.comment.constant.Keyword;
 import com.cafein.backend.domain.comment.entity.Comment;
 import com.cafein.backend.domain.comment.repository.CommentRepository;
+import com.cafein.backend.domain.commentkeyword.entity.CommentKeyword;
+import com.cafein.backend.domain.commentkeyword.repository.CommentKeywordRepository;
+import com.cafein.backend.domain.member.entity.Member;
+import com.cafein.backend.domain.member.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class CommentService {
 
 	private final CommentRepository commentRepository;
+	private final CommentKeywordRepository commentKeywordRepository;
+	private final MemberService memberService;
+	private final CafeService cafeService;
 
-	@Transactional(readOnly = true)
-	public Integer countByCafeId(Long cafeId) {
-		return commentRepository.countCommentByCafeId(cafeId);
+	public void addComment(final CommentDTO.Request requestDTO, final Long cafeId, final Long memberId) {
+		Comment comment = createCafeComment(requestDTO, cafeId, memberId);
+		commentRepository.save(comment);
+	}
+
+	private Comment createCafeComment(final CommentDTO.Request requestDTO, final Long cafeId, final Long memberId) {
+		final Member member = memberService.findMemberByMemberId(memberId);
+		final Cafe cafe = cafeService.findCafeByCafeId(cafeId);
+		Comment comment = Comment.builder()
+			.content(requestDTO.getContent())
+			.cafe(cafe)
+			.member(member)
+			.build();
+		for (String key : requestDTO.getKeywords()) {
+			commentKeywordRepository.save(createCommentKeyword(comment, key));
+		}
+		return comment;
+	}
+
+	private CommentKeyword createCommentKeyword(final Comment comment, final String key) {
+		return CommentKeyword.builder()
+			.keyword(Keyword.from(key))
+			.comment(comment)
+			.build();
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/commentkeyword/entity/CommentKeyword.java
+++ b/backend/src/main/java/com/cafein/backend/domain/commentkeyword/entity/CommentKeyword.java
@@ -1,4 +1,4 @@
-package com.cafein.backend.domain.comment.entity;
+package com.cafein.backend.domain.commentkeyword.entity;
 
 import static javax.persistence.FetchType.*;
 
@@ -12,8 +12,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import com.cafein.backend.domain.comment.constant.Keyword;
+import com.cafein.backend.domain.comment.entity.Comment;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,4 +34,10 @@ public class CommentKeyword {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "comment_id")
 	private Comment comment;
+
+	@Builder
+	public CommentKeyword(final Keyword keyword, final Comment comment) {
+		this.keyword = keyword;
+		this.comment = comment;
+	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/commentkeyword/repository/CommentKeywordRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/commentkeyword/repository/CommentKeywordRepository.java
@@ -1,0 +1,8 @@
+package com.cafein.backend.domain.commentkeyword.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.cafein.backend.domain.commentkeyword.entity.CommentKeyword;
+
+public interface CommentKeywordRepository extends JpaRepository<CommentKeyword, Long> {
+}

--- a/backend/src/main/java/com/cafein/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/review/service/ReviewService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.cafein.backend.api.review.dto.ReviewDTO;
-import com.cafein.backend.domain.cafe.repository.CafeRepository;
+import com.cafein.backend.domain.cafe.service.CafeService;
 import com.cafein.backend.domain.member.entity.Member;
 import com.cafein.backend.domain.member.service.MemberService;
 import com.cafein.backend.domain.review.constant.CafeCongestion;
@@ -26,7 +26,7 @@ public class ReviewService {
 
 	private final MemberService memberService;
 	private final ReviewRepository reviewRepository;
-	private final CafeRepository cafeRepository;
+	private final CafeService cafeService;
 
 	public ReviewDTO.Response createReview(final ReviewDTO.Request requestDTO, final Long cafeId, final Long memberId) {
 		Member member = memberService.findMemberByMemberId(memberId);
@@ -39,7 +39,7 @@ public class ReviewService {
 
 	private Review createReview(final ReviewDTO.Request requestDTO, final Long cafeId, final Member member) {
 		return Review.builder()
-			.cafe(cafeRepository.findById(cafeId).orElseThrow(() -> new BusinessException(ErrorCode.CAFE_NOT_EXIST)))
+			.cafe(cafeService.findCafeByCafeId(cafeId))
 			.cafeCongestion(CafeCongestion.valueOf(requestDTO.getCafeCongestion()))
 			.isClean(Boolean.parseBoolean(requestDTO.getIsClean()))
 			.hasPlug(Boolean.parseBoolean(requestDTO.getHasPlug()))

--- a/backend/src/main/java/com/cafein/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/cafein/backend/global/error/ErrorCode.java
@@ -7,9 +7,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-	TEST(HttpStatus.INTERNAL_SERVER_ERROR, "001", "business exception test"),
-
-	//인증
+	// 인증
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A-001", "토큰이 만료되었습니다."),
 	NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "A-002", "해당 토큰은 유효한 토큰이 아닙니다."),
 	NOT_EXISTS_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "A-003", "Authorization Header가 빈값입니다."),
@@ -18,21 +16,24 @@ public enum ErrorCode {
 	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A-006", "해당 Refresh Token은 만료 되었습니다."),
 	NOT_ACCESS_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "A-007", "해당 토큰은 Access Token이 아닙니다."),
 
-	//회원
+	// 회원
 	INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "M-001", "잘못된 회원 타입 입니다."),
 	ALREADY_REGISTERED_MEMBER(HttpStatus.BAD_REQUEST, "M-002", "이미 가입된 회원입니다."),
 	MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST, "M-003", "해당 회원은 존재하지 않습니다."),
 	NOT_ENOUGH_COFFEE_BEAN(HttpStatus.BAD_REQUEST, "M-004", "커피 콩이 부족합니다."),
 
-	//카페
+	// 카페
 	CAFE_NOT_EXIST(HttpStatus.BAD_REQUEST, "C-001", "해당 카페는 존재하지 않습니다."),
 	CAFE_ALREADY_VIEWED(HttpStatus.BAD_REQUEST, "C-002", "이미 조회한 카페입니다."),
 
-	//지역
+	// 지역
 	LOCAL_NOT_EXIST(HttpStatus.BAD_REQUEST, "L-001", "해당 지역은 존재하지 않습니다."),
 
-	//리뷰
-	REVIEWED_CAFE_WITHIN_A_DAY(HttpStatus.BAD_REQUEST, "R-001", "해당 카페에 대해 하루에 한번만 리뷰를 작성할 수 있습니다.");
+	// 리뷰
+	REVIEWED_CAFE_WITHIN_A_DAY(HttpStatus.BAD_REQUEST, "R-001", "해당 카페에 대해 하루에 한번만 리뷰를 작성할 수 있습니다."),
+
+	// 댓글
+	KEYWORD_NOT_EXIST(HttpStatus.BAD_REQUEST,"CO-001","해당 키워드는 존재하지 않습니다.");
 
 	private HttpStatus httpStatus;
 	private String errorCode;


### PR DESCRIPTION
## 이슈 링크

#67 

## 변경된 동작

- 댓글을 등록하는 API를 추가했습니다.
- 카페 Id로 카페를 조회 시 댓글을 전부 불러오도록 변경했습니다.

## 특이 사항
.

## 체크리스트

- [x] 코드가 모든 유닛 테스트를 통과했습니다.
- [ ] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
- [x] 변경사항에 대한 문서가 업데이트 되었습니다.
