### PR TITLE
Refactor/member #74

### DIFF
--- a/backend/src/main/java/com/cafein/backend/api/login/service/OAuthLoginService.java
+++ b/backend/src/main/java/com/cafein/backend/api/login/service/OAuthLoginService.java
@@ -34,7 +34,7 @@ public class OAuthLoginService {
 		log.info("userInfo : {}", userInfo);
 
 		JwtTokenDTO jwtTokenDTO;
-		Optional<Member> optionalMember = memberService.findMemberByEmail(userInfo.getEmail());
+		Optional<Member> optionalMember = memberService.findMemberByEmailAndMemberType(userInfo.getEmail(), userInfo.getMemberType());
 		if (optionalMember.isEmpty()) {		//신규 회원가입
 			Member oauthMember = userInfo.toMemberEntity(memberType, Role.USER);
 			oauthMember = memberService.registerMember(oauthMember);

--- a/backend/src/main/java/com/cafein/backend/api/member/controller/MemberController.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/controller/MemberController.java
@@ -1,14 +1,20 @@
 package com.cafein.backend.api.member.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.cafein.backend.api.member.dto.MemberInfoResponseDTO;
 import com.cafein.backend.api.member.dto.MyPageDTO;
+import com.cafein.backend.api.member.dto.NameChangeRequestDTO;
 import com.cafein.backend.api.member.service.MemberInfoService;
 import com.cafein.backend.api.member.service.MyPageService;
+import com.cafein.backend.domain.member.service.MemberService;
 import com.cafein.backend.global.resolver.MemberInfo;
 import com.cafein.backend.global.resolver.MemberInfoDTO;
 
@@ -27,6 +33,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @RequestMapping("/api/member")
 public class MemberController {
 
+	private final MemberService memberService;
 	private final MemberInfoService memberInfoService;
 	private final MyPageService myPageService;
 
@@ -54,5 +61,14 @@ public class MemberController {
 	@GetMapping("/mypage")
 	public ResponseEntity<MyPageDTO> getMyPage(@ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
 		return ResponseEntity.ok(myPageService.getMyPageDTO(memberInfoDTO.getMemberId()));
+	}
+
+	@Tag(name = "member")
+	@Operation(summary = "회원 이름(닉네임) 수정 API", description = "회원 이름(닉네임) 수정 API")
+	@PatchMapping("/name")
+	public ResponseEntity<String> updateMemberName(@ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO,
+												 @Valid @RequestBody NameChangeRequestDTO nameChangeRequestDTO) {
+		memberService.updateMemberName(memberInfoDTO.getMemberId(), nameChangeRequestDTO.getName());
+		return ResponseEntity.ok("Name change successful!");
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/api/member/dto/NameChangeRequestDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/member/dto/NameChangeRequestDTO.java
@@ -1,0 +1,14 @@
+package com.cafein.backend.api.member.dto;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class NameChangeRequestDTO {
+
+	@Schema(name = "name", description = "변경하고 싶은 닉네임", example = "커피몬스터", required = true)
+	@NotNull
+	private String name;
+}

--- a/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
@@ -96,6 +96,10 @@ public class Member extends BaseTimeEntity {
 		this.tokenExpirationTime = DateTimeUtils.convertDateToLocalDateTime(jwtTokenDto.getRefreshTokenExpireTime());
 	}
 
+	public void updateName(final String name) {
+		this.name = name;
+	}
+
 	public void expireRefreshToken(final LocalDateTime now) {
 		this.tokenExpirationTime = now;
 	}

--- a/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
@@ -45,7 +45,7 @@ public class Member extends BaseTimeEntity {
 	@Column(nullable = false, length = 10)
 	private MemberType memberType;
 
-	@Column(unique = true, length = 50, nullable = false)
+	@Column(length = 50, nullable = false)
 	private String email;
 
 	@Column(length = 200)

--- a/backend/src/main/java/com/cafein/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/repository/MemberRepository.java
@@ -4,10 +4,13 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.cafein.backend.domain.member.constant.MemberType;
 import com.cafein.backend.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
 
 	Optional<Member> findByRefreshToken(String refreshToken);
+
+	Optional<Member> findByEmailAndMemberType(String email, MemberType memberType);
 }

--- a/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
@@ -29,7 +29,7 @@ public class MemberService {
 	}
 
 	private void validateDuplicateMember(Member member) {
-		Optional<Member> optionalMember = memberRepository.findByEmail(member.getEmail());
+		Optional<Member> optionalMember = memberRepository.findByEmailAndMemberType(member.getEmail(), member.getMemberType());
 		if (optionalMember.isPresent()) {
 			throw new BusinessException(ErrorCode.ALREADY_REGISTERED_MEMBER);
 		}

--- a/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
@@ -36,6 +36,11 @@ public class MemberService {
 	}
 
 	@Transactional(readOnly = true)
+	public Optional<Member> findMemberByEmailAndMemberType(String email, MemberType memberType) {
+		return memberRepository.findByEmailAndMemberType(email, memberType);
+	}
+
+	@Transactional(readOnly = true)
 	public Optional<Member> findMemberByEmail(String email) {
 		return memberRepository.findByEmail(email);
 	}
@@ -66,8 +71,10 @@ public class MemberService {
 		member.subtractCoffeeBean(member.getCoffeeBean());
 	}
 
-	@Transactional(readOnly = true)
-	public Optional<Member> findMemberByEmailAndMemberType(String email, MemberType memberType) {
-		return memberRepository.findByEmailAndMemberType(email, memberType);
+	@Transactional
+	public void updateMemberName(Long memberId, String name) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST));
+		member.updateName(name);
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.cafein.backend.domain.member.constant.MemberType;
 import com.cafein.backend.domain.member.entity.Member;
 import com.cafein.backend.domain.member.repository.MemberRepository;
 import com.cafein.backend.global.error.ErrorCode;
@@ -56,7 +57,6 @@ public class MemberService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST));
 	}
 
-	@Transactional
 	public void subtractCoffeeBean(final Long memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_EXIST));
@@ -64,5 +64,10 @@ public class MemberService {
 			throw new BusinessException(ErrorCode.NOT_ENOUGH_COFFEE_BEAN);
 		}
 		member.subtractCoffeeBean(member.getCoffeeBean());
+	}
+
+	@Transactional(readOnly = true)
+	public Optional<Member> findMemberByEmailAndMemberType(String email, MemberType memberType) {
+		return memberRepository.findByEmailAndMemberType(email, memberType);
 	}
 }

--- a/backend/src/main/java/com/cafein/backend/external/oauth/model/OAuthAttributes.java
+++ b/backend/src/main/java/com/cafein/backend/external/oauth/model/OAuthAttributes.java
@@ -1,5 +1,7 @@
 package com.cafein.backend.external.oauth.model;
 
+import java.util.UUID;
+
 import com.cafein.backend.domain.member.constant.MemberType;
 import com.cafein.backend.domain.member.constant.Role;
 import com.cafein.backend.domain.member.entity.Member;
@@ -21,12 +23,16 @@ public class OAuthAttributes {
 
 	public Member toMemberEntity(MemberType memberType, Role role) {
 		return Member.builder()
-			.name(name)
+			.name(createRandomName())
 			.email(email)
 			.memberType(memberType)
 			.profile(profile)
 			.role(role)
 			.coffeeBean(COFFEE_BEAN)
 			.build();
+	}
+
+	private String createRandomName() {
+		return "커피곰#" + UUID.randomUUID().toString().substring(0, 5);
 	}
 }

--- a/backend/src/test/java/com/cafein/backend/core/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/cafein/backend/core/member/domain/MemberTest.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
-import com.cafein.backend.domain.member.entity.Member;
 import com.cafein.backend.global.util.DateTimeUtils;
 
 class MemberTest {
@@ -34,5 +33,11 @@ class MemberTest {
 		MEMBER.subtractCoffeeBean(MEMBER.getCoffeeBean());
 
 		assertThat(MEMBER.getCoffeeBean()).isEqualTo(98);
+	}
+
+	@Test
+	void 회원의_닉네임을_수정한다() {
+		MEMBER.updateName(MEMBER.getName());
+		assertThat(MEMBER.getName()).isEqualTo("황의찬");
 	}
 }

--- a/backend/src/test/java/com/cafein/backend/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/MemberServiceTest.java
@@ -29,7 +29,7 @@ class MemberServiceTest {
 	@Test
 	void 회원_등록을_한다() {
 		given(memberRepository.save(any())).willReturn(MEMBER);
-		given(memberRepository.findByEmail(any())).willReturn(Optional.empty());
+		given(memberRepository.findByEmailAndMemberType(any(), any())).willReturn(Optional.empty());
 
 		memberService.registerMember(MEMBER);
 
@@ -38,7 +38,7 @@ class MemberServiceTest {
 
 	@Test
 	void 회원_등록시_이미_가입된_회원이면_예외를_던진다() {
-		given(memberRepository.findByEmail(any())).willReturn(Optional.of(MEMBER));
+		given(memberRepository.findByEmailAndMemberType(any(), any())).willReturn(Optional.of(MEMBER));
 
 		assertThatThrownBy(() -> memberService.registerMember(MEMBER))
 			.isInstanceOf(BusinessException.class)
@@ -52,6 +52,15 @@ class MemberServiceTest {
 		memberService.findMemberByEmail(MEMBER.getEmail());
 
 		then(memberRepository).should(times(1)).findByEmail(anyString());
+	}
+
+	@Test
+	void 이메일과_멤버타입으로_회원을_조회한다() {
+		given(memberRepository.findByEmailAndMemberType(any(), any())).willReturn(Optional.of(MEMBER));
+
+		memberService.findMemberByEmailAndMemberType(MEMBER.getEmail(), MEMBER.getMemberType());
+
+		then(memberRepository).should(times(1)).findByEmailAndMemberType(any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
## 변경 내용
 회원가입 중복 로직 수정
 회원가입시 랜덤 닉네임 부여
 닉네임 수정 추가

## 이슈 링크
#74 

## 변경된 동작
현재는 이메일로만 중복을 확인하기 때문에, 카카오 로그인과 구글 로그인의 이메일이 겹칠경우 회원가입이 되지 않는다.
하지만 카카오 이메일은 구글 이메일과 같을 수 있으므로, (멤버타입, 이메일)이 쌍으로 중복확인을 하도록 변경.

회원가입시 각 회원에게 랜덤한 닉네임을 부여하도록 변경.

닉네임 수정 기능 추가.

## 특이 사항
테스트 코드 수정/추가 해야합니다.

## 체크리스트

- [x] 코드가 모든 유닛 테스트를 통과했습니다.
- [x] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
- [x] 변경사항에 대한 문서가 업데이트 되었습니다.
