### PR TITLE
feat: 데이터베이스 칼럼에 인덱스를 생성한다

### DIFF
--- a/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/entity/Member.java
@@ -13,7 +13,9 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
@@ -35,6 +37,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+		@Index(name = "idx_email_memberType", columnList = "email, memberType", unique = true),
+		@Index(name = "idx_refresh_token", columnList = "refreshToken")
+})
 public class Member extends BaseTimeEntity {
 
 	@Id

--- a/backend/src/main/java/com/cafein/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/member/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import com.cafein.backend.domain.member.constant.MemberType;
 import com.cafein.backend.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
 	Optional<Member> findByEmail(String email);
 
 	Optional<Member> findByRefreshToken(String refreshToken);

--- a/backend/src/main/java/com/cafein/backend/domain/viewedcafe/entity/ViewedCafe.java
+++ b/backend/src/main/java/com/cafein/backend/domain/viewedcafe/entity/ViewedCafe.java
@@ -25,7 +25,7 @@ public class ViewedCafe extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+	private Long viewedCafeId;
 
 	@Column(nullable = false)
 	private Long cafeId;


### PR DESCRIPTION
## 변경 내용

member 테이블 칼럼에 인덱스 추가 

## 이슈 링크

#87 

## 변경된 동작

member 테이블의 `email`, `memberType` 칼럼에 유니크 인덱스를 적용했습니다. (조회 쿼리 성능 `0.79 sec -> 0.00089 sec`)
member 테이블의 `refreshToken` 칼럼에 유니크 인덱스를 적용했습니다. (조회 쿼리 성능 `1.9 sec -> 0.0018sec`)
https://walnut-particle-53c.notion.site/SQL-96b0c26c6a554d199878be5ac60f8c5d

## 특이 사항

.

## 체크리스트

- [x] 코드가 모든 유닛 테스트를 통과했습니다.
- [x] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
- [x] 변경사항에 대한 문서가 업데이트 되었습니다.
