### PR TITLE
refactor: 서비스 계층 테스트를 @SpringBootTest를 사용하지 않도록 변경한다

### DIFF
--- a/backend/src/test/java/com/cafein/backend/service/CafeServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/CafeServiceTest.java
@@ -7,8 +7,8 @@ import static org.mockito.BDDMockito.*;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import com.cafein.backend.api.cafe.dto.CafeDTO;
 import com.cafein.backend.domain.cafe.repository.CafeRepository;
@@ -18,10 +18,10 @@ import com.cafein.backend.support.utils.ServiceTest;
 @ServiceTest
 class CafeServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private CafeService cafeService;
 
-	@MockBean
+	@Mock
 	private CafeRepository cafeRepository;
 
 	@Test

--- a/backend/src/test/java/com/cafein/backend/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/CommentServiceTest.java
@@ -6,8 +6,13 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
 import com.cafein.backend.domain.comment.entity.Comment;
@@ -18,6 +23,7 @@ import com.cafein.backend.support.utils.DataBaseSupporter;
 import com.cafein.backend.support.utils.ServiceTest;
 
 @ServiceTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql("/sql/comment.sql")
 class CommentServiceTest extends DataBaseSupporter {
 

--- a/backend/src/test/java/com/cafein/backend/service/LogoutServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/LogoutServiceTest.java
@@ -7,10 +7,9 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.cafein.backend.api.logout.service.LogoutService;
 import com.cafein.backend.domain.member.entity.Member;
@@ -23,13 +22,13 @@ import io.jsonwebtoken.Claims;
 @ServiceTest
 class LogoutServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private LogoutService logoutService;
 
-	@MockBean
+	@Mock
 	private MemberService memberService;
 
-	@MockBean
+	@Mock
 	private TokenManager tokenManager;
 
 	@Spy

--- a/backend/src/test/java/com/cafein/backend/service/MemberInfoServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/MemberInfoServiceTest.java
@@ -1,35 +1,44 @@
 package com.cafein.backend.service;
 
+import static com.cafein.backend.support.fixture.CafeFixture.*;
 import static com.cafein.backend.support.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 
 import com.cafein.backend.api.member.dto.MemberInfoResponseDTO;
 import com.cafein.backend.api.member.service.MemberInfoService;
+import com.cafein.backend.domain.member.repository.MemberRepository;
 import com.cafein.backend.domain.member.service.MemberService;
-import com.cafein.backend.support.utils.DataBaseSupporter;
+import com.cafein.backend.domain.viewedcafe.repository.ViewedCafeRepository;
+import com.cafein.backend.domain.viewedcafe.service.ViewedCafeService;
+import com.cafein.backend.support.fixture.CafeFixture;
 import com.cafein.backend.support.utils.ServiceTest;
 
 @ServiceTest
 class MemberInfoServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private MemberInfoService memberInfoService;
 
-	@MockBean
+	@Mock
 	private MemberService memberService;
+
+	@Mock
+	private ViewedCafeService viewedCafeService;
 
 	@Test
 	void 회원_정보를_가져온다() {
 		given(memberService.findMemberByMemberId(anyLong())).willReturn(MEMBER);
+		given(viewedCafeService.findViewedCafes(anyLong())).willReturn(VIEWED_CAFE_IDS);
 
-		MemberInfoResponseDTO memberInfoResponseDTO = memberInfoService.getMemberInfo(MEMBER.getMemberId());
+		memberInfoService.getMemberInfo(MEMBER.getMemberId());
 
 		then(memberService).should(times(1)).findMemberByMemberId(anyLong());
-		assertThat(memberInfoResponseDTO.getMemberId()).isNotNull();
+		then(viewedCafeService).should(times(1)).findViewedCafes(anyLong());
 	}
 }

--- a/backend/src/test/java/com/cafein/backend/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/MemberServiceTest.java
@@ -7,8 +7,8 @@ import static org.mockito.BDDMockito.*;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import com.cafein.backend.domain.member.entity.Member;
 import com.cafein.backend.domain.member.repository.MemberRepository;
@@ -20,10 +20,10 @@ import com.cafein.backend.support.utils.ServiceTest;
 @ServiceTest
 class MemberServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private MemberService memberService;
 
-	@MockBean
+	@Mock
 	private MemberRepository memberRepository;
 
 	@Test

--- a/backend/src/test/java/com/cafein/backend/service/MyPageServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/MyPageServiceTest.java
@@ -6,25 +6,30 @@ import static org.mockito.BDDMockito.*;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import com.cafein.backend.api.member.dto.MyPageDTO;
 import com.cafein.backend.api.member.service.MyPageService;
 import com.cafein.backend.domain.cafe.service.CafeService;
 import com.cafein.backend.domain.review.respository.ReviewRepository;
+import com.cafein.backend.domain.viewedcafe.service.ViewedCafeService;
+import com.cafein.backend.support.fixture.CafeFixture;
 import com.cafein.backend.support.utils.ServiceTest;
 
 @ServiceTest
 class MyPageServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private MyPageService myPageService;
 
-	@MockBean
+	@Mock
 	private ReviewRepository reviewRepository;
 
-	@MockBean
+	@Mock
+	private ViewedCafeService viewedCafeService;
+
+	@Mock
 	private CafeService cafeService;
 
 	@Test
@@ -32,6 +37,7 @@ class MyPageServiceTest {
 		given(cafeService.findCafeInfoViewedByMember(any())).willReturn(Collections.emptyList());
 		given(reviewRepository.findReviewsByMemberId(anyLong())).willReturn(Collections.emptyList());
 		given(reviewRepository.countReviewByMemberId(anyLong())).willReturn(5L);
+		given(viewedCafeService.findViewedCafes(anyLong())).willReturn(CafeFixture.VIEWED_CAFE_IDS);
 
 		final MyPageDTO myPageDTO = myPageService.getMyPageDTO(1L);
 

--- a/backend/src/test/java/com/cafein/backend/service/OAuthLoginServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/OAuthLoginServiceTest.java
@@ -9,7 +9,10 @@ import java.util.Date;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.cafein.backend.api.login.dto.OAuthLoginDTO;
@@ -21,6 +24,7 @@ import com.cafein.backend.external.oauth.kakao.service.KakaoLoginApiServiceImpl;
 import com.cafein.backend.support.utils.ServiceTest;
 
 @ServiceTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class OAuthLoginServiceTest {
 
 	@Autowired
@@ -34,20 +38,6 @@ class OAuthLoginServiceTest {
 
 	@MockBean
 	private GoogleLoginApiServiceImpl googleLoginApiServiceImpl;
-
-	@Test
-	void 카카오_로그인을_시도하면_true를_반환한다() {
-		given(kakaoLoginApiServiceImpl.getUserInfo(ACCESS_TOKEN)).willReturn(KAKAO_OAUTH_ATTRIBUTES);
-		given(memberService.registerMember(any())).willReturn(MEMBER);
-		assertThatNoException().isThrownBy(() -> oAuthLoginService.oauthLogin(ACCESS_TOKEN, MemberType.KAKAO));
-	}
-
-	@Test
-	void 구글_로그인을_시도하면_true를_반환한다() {
-		given(googleLoginApiServiceImpl.getUserInfo(ACCESS_TOKEN)).willReturn(GOOGLE_OAUTH_ATTRIBUTES);
-		given(memberService.registerMember(any())).willReturn(MEMBER);
-		assertThatNoException().isThrownBy(() -> oAuthLoginService.oauthLogin(ACCESS_TOKEN, MemberType.GOOGLE));
-	}
 
 	@Test
 	void 신규로_로그인을하면_회원을_등록하고_토큰을_생성한다() {

--- a/backend/src/test/java/com/cafein/backend/service/ReviewServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/ReviewServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import com.cafein.backend.domain.cafe.entity.Cafe;
 import com.cafein.backend.domain.cafe.service.CafeService;
@@ -21,16 +21,16 @@ import com.cafein.backend.support.utils.ServiceTest;
 @ServiceTest
 class ReviewServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private ReviewService reviewService;
 
-	@MockBean
+	@Mock
 	private MemberService memberService;
 
-	@MockBean
+	@Mock
 	private CafeService cafeService;
 
-	@MockBean
+	@Mock
 	private ReviewRepository reviewRepository;
 
 	@Test

--- a/backend/src/test/java/com/cafein/backend/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/service/TokenServiceTest.java
@@ -1,5 +1,6 @@
 package com.cafein.backend.service;
 
+import static com.cafein.backend.support.fixture.LoginFixture.*;
 import static com.cafein.backend.support.fixture.MemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -7,9 +8,8 @@ import static org.mockito.BDDMockito.*;
 import java.util.Date;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import com.cafein.backend.api.token.dto.AccessTokenResponseDTO;
 import com.cafein.backend.api.token.service.TokenService;
@@ -20,23 +20,25 @@ import com.cafein.backend.support.utils.ServiceTest;
 @ServiceTest
 class TokenServiceTest {
 
-	@Autowired
+	@InjectMocks
 	private TokenService tokenService;
 
-	@MockBean
+	@Mock
 	private MemberService memberService;
 
-	@SpyBean
+	@Mock
 	private TokenManager tokenManager;
 
 	@Test
 	void access_Token_재발급을_테스트한다() {
 		given(memberService.findMemberByRefreshToken(anyString())).willReturn(MEMBER);
 		given(tokenManager.createAccessTokenExpireTime()).willReturn(
-			new Date(System.currentTimeMillis() + Long.parseLong("900000")));
+			new Date(System.currentTimeMillis() + Long.parseLong("900000"))
+		);
+		given(tokenManager.createAccessToken(anyLong(), any(), any(Date.class))).willReturn(ACCESS_TOKEN);
 
-		AccessTokenResponseDTO accessTokenResponseDTO = tokenService.
-			createAccessTokenByRefreshToken(MEMBER.getRefreshToken());
+		AccessTokenResponseDTO accessTokenResponseDTO = tokenService
+			.createAccessTokenByRefreshToken(MEMBER.getRefreshToken());
 
 		then(tokenManager).should(times(1)).createAccessToken(anyLong(), any(), any(Date.class));
 

--- a/backend/src/test/java/com/cafein/backend/support/utils/ServiceTest.java
+++ b/backend/src/test/java/com/cafein/backend/support/utils/ServiceTest.java
@@ -17,6 +17,5 @@ import org.springframework.boot.test.context.SpringBootTest;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public @interface ServiceTest {
 }


### PR DESCRIPTION
## 변경 내용
Service Layer Test에서 @SpringBootTest를 사용하지 않도록 변경

## 이슈 링크
#92 

## 특이 사항
OAuthLoginServiceTest & CommentServiceTest는 아직 변경하지 않음

## 체크리스트

- [x] 코드가 모든 유닛 테스트를 통과했습니다.
- [x] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
- [x] 변경사항에 대한 문서가 업데이트 되었습니다.
