### PR TITLE
feat: 리뷰가 없을 때의 상태를 반영한다

### DIFF
--- a/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
@@ -40,7 +40,7 @@ public class CafeController {
 	})
 	@GetMapping("/cafe/{cafeId}")
 	public ResponseEntity<CafeDTO> cafeInfo(@PathVariable Long cafeId,
-											    @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
+										    @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
 		return ResponseEntity.ok(cafeService.findCafeInfoById(memberInfoDTO.getMemberId(), cafeId));
 	}
 
@@ -52,7 +52,7 @@ public class CafeController {
 	})
 	@PostMapping("/cafe/{cafeId}")
 	public ResponseEntity<CafeDTO> cafeCongestionCheck(@PathVariable Long cafeId,
-								           		           @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
+		                                               @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
 		log.debug("memberId = {}", memberInfoDTO.getMemberId());
 		final Long memberId = memberInfoDTO.getMemberId();
 		viewedCafeService.validateCongestionRequest(memberId, cafeId);

--- a/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.cafein.backend.api.cafe.dto.CafeDTO;
 import com.cafein.backend.domain.cafe.service.CafeService;
 import com.cafein.backend.domain.member.service.MemberService;
+import com.cafein.backend.domain.review.service.ReviewService;
 import com.cafein.backend.domain.viewedcafe.service.ViewedCafeService;
 import com.cafein.backend.global.resolver.MemberInfo;
 import com.cafein.backend.global.resolver.MemberInfoDTO;
@@ -31,6 +32,7 @@ public class CafeController {
 
 	private final MemberService	memberService;
 	private final CafeService cafeService;
+	private final ReviewService reviewService;
 	private final ViewedCafeService viewedCafeService;
 
 	@Tag(name = "cafe")
@@ -54,6 +56,7 @@ public class CafeController {
 	public ResponseEntity<CafeDTO> cafeCongestionCheck(@PathVariable Long cafeId,
 		                                               @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
 		final Long memberId = memberInfoDTO.getMemberId();
+		reviewService.validateReviewExists(cafeId);
 		viewedCafeService.validateCongestionRequest(memberId, cafeId);
 		memberService.subtractCoffeeBean(memberId);
 		viewedCafeService.addViewedCafe(memberService.findMemberByMemberId(memberId), cafeId);

--- a/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/controller/CafeController.java
@@ -34,7 +34,7 @@ public class CafeController {
 	private final ViewedCafeService viewedCafeService;
 
 	@Tag(name = "cafe")
-	@Operation(summary = "카페 상세보기 API(커피콩을 사용해서 이미 조회한 카페)", description = "카페 정보를 조회하는 API")
+	@Operation(summary = "카페 상세보기 API", description = "카페 정보를 조회하는 API")
 	@ApiResponses({
 		@ApiResponse(responseCode = "C-001", description = "해당 카페는 존재하지 않습니다.")
 	})
@@ -53,7 +53,6 @@ public class CafeController {
 	@PostMapping("/cafe/{cafeId}")
 	public ResponseEntity<CafeDTO> cafeCongestionCheck(@PathVariable Long cafeId,
 		                                               @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO) {
-		log.debug("memberId = {}", memberInfoDTO.getMemberId());
 		final Long memberId = memberInfoDTO.getMemberId();
 		viewedCafeService.validateCongestionRequest(memberId, cafeId);
 		memberService.subtractCoffeeBean(memberId);

--- a/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeDTO.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeDTO.java
@@ -3,14 +3,21 @@ package com.cafein.backend.api.cafe.dto;
 import java.util.List;
 
 import com.cafein.backend.api.comment.dto.CommentInfoDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+@JsonPropertyOrder({
+	"cafeInfo",
+	"comment"
+})
 @Getter @Builder
 public class CafeDTO {
 
+	@JsonProperty("cafeInfo")
 	private CafeInfoProjection cafeInfoProjection;
 
 	@Schema(name = "comment", description = "카페 리뷰", type = "array", example = "[commentId, memberName, createdTime, content, keywords = []]", required = true)

--- a/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeInfoProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeInfoProjection.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 	"cafeId",
 	"name",
 	"averageCongestion",
+	"hasReviewed",
 	"hasPlugCount",
 	"isCleanCount",
 	"phoneNumber",
@@ -27,6 +28,9 @@ public interface CafeInfoProjection {
 
 	@Schema(description = "카페 번호", example = "050713337616", required = true)
 	String getPhoneNumber();
+
+	@Schema(description = "리뷰 여부", example = "true", required = true)
+	String getHasReviewed();
 
 	@Schema(description = "카페 주소", example = "서울시 성동구 서울숲2길44-13 1층", required = true)
 	String getAddress();

--- a/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeInfoProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/cafe/dto/CafeInfoProjection.java
@@ -1,7 +1,22 @@
 package com.cafein.backend.api.cafe.dto;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonPropertyOrder({
+	"cafeId",
+	"name",
+	"averageCongestion",
+	"hasPlugCount",
+	"isCleanCount",
+	"phoneNumber",
+	"address",
+	"status",
+	"local",
+	"latitude",
+	"longitude"
+})
 public interface CafeInfoProjection {
 
 	@Schema(description = "카페 이름", example = "5to7", required = true)

--- a/backend/src/main/java/com/cafein/backend/api/home/dto/HomeProjection.java
+++ b/backend/src/main/java/com/cafein/backend/api/home/dto/HomeProjection.java
@@ -1,8 +1,22 @@
 
 package com.cafein.backend.api.home.dto;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonPropertyOrder({
+	"cafeId",
+	"name",
+	"phoneNumber",
+	"address",
+	"status",
+	"commentReviewCount",
+	"averageCongestion",
+	"local",
+	"latitude",
+	"longitude"
+})
 public interface HomeProjection {
 
 	@Schema(description = "카페 이름", example = "5to7", required = true)

--- a/backend/src/main/java/com/cafein/backend/api/login/controller/OAuthLoginController.java
+++ b/backend/src/main/java/com/cafein/backend/api/login/controller/OAuthLoginController.java
@@ -56,7 +56,7 @@ public class OAuthLoginController {
 			.from("refresh_token", jwtTokenOAuthLoginResponseDTO.getRefreshToken())
 			.httpOnly(true)
 			.sameSite("Strict")
-			.maxAge(60 * 60 * 24 * 14)		//2주
+			.maxAge(60 * 60 * 24 * 14)
 			.build();
 
 		httpServletResponse.setHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());

--- a/backend/src/main/java/com/cafein/backend/api/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/cafein/backend/api/review/controller/ReviewController.java
@@ -44,10 +44,8 @@ public class ReviewController {
 	})
 	@PostMapping("/cafe/{cafeId}/review")
 	public ResponseEntity<ReviewResponse> createCafeReview(@Valid @RequestBody ReviewRequest reviewRequestDTO,
-		 													   @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO,
-							  					 			   @PathVariable Long cafeId) {
-		// TODO 동시성 처리 필요
-		log.debug("memberId = {}", memberInfoDTO.getMemberId());
+		 												   @ApiIgnore @MemberInfo MemberInfoDTO memberInfoDTO,
+									                       @PathVariable Long cafeId) {
 		reviewService.validateReview(memberInfoDTO.getMemberId(), cafeId);
 		ReviewResponse reviewResponse = reviewService.createReview(reviewRequestDTO, cafeId, memberInfoDTO.getMemberId());
 		return ResponseEntity.created(URI.create("/api/cafe/" + cafeId + "/review/" + reviewResponse.getReviewId()))

--- a/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
@@ -54,6 +54,7 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
 		+ "(SELECT COUNT(is_clean) FROM review r WHERE c.cafe_id = r.cafe_id AND r.is_clean=1) AS 'isCleanCount', "
 		+ "COALESCE(c.phone_number, '등록된 전화번호가 없습니다') AS 'phoneNumber', "
 		+ "CONCAT(c.sigungu, ' ', c.road_name, c.house_number) AS 'address', "
+		+ "(SELECT CASE WHEN COUNT(r.cafe_id) > 0 THEN 'true' ELSE 'false' END FROM  review r WHERE r.cafe_id = :cafeId) AS 'hasReviewed', "
 		+ "CASE WHEN CURRENT_TIME() BETWEEN oh.open_time AND oh.close_time THEN '영업중' ELSE '영업종료' END AS 'status', "
 		+ "CASE WHEN vc.cafe_id IS NOT NULL THEN CAST(COALESCE(avg_congestion.avg_congestion, 0) AS UNSIGNED) ELSE '0' END AS 'averageCongestion'"
 		+ "FROM cafe c "
@@ -89,4 +90,7 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
 	Optional<Cafe> findByName(String name);
 
 	long count();
+
+	@Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END FROM Review r WHERE r.cafe.cafeId = :cafeId")
+	boolean existsReviewByCafeId(Long cafeId);
 }

--- a/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/cafe/repository/CafeRepository.java
@@ -40,7 +40,7 @@ public interface CafeRepository extends JpaRepository<Cafe, Long> {
 		+ "avg_congestion ON c.cafe_id = avg_congestion.cafe_id "
 		+ "LEFT JOIN "
 		+ "viewed_cafe vc ON c.cafe_id = vc.cafe_id AND vc.member_id = :memberId "
-		+ "ORDER BY "
+		+ "ORDER BY c.cafe_id, "
 		+ "(COALESCE(r.review_count, 0) + COALESCE(co.comment_count, 0)) DESC, c.name ", nativeQuery = true)
 	List<HomeProjection> getHomeData(@Param("memberId") Long memberId);
 

--- a/backend/src/main/java/com/cafein/backend/domain/review/respository/ReviewRepository.java
+++ b/backend/src/main/java/com/cafein/backend/domain/review/respository/ReviewRepository.java
@@ -23,13 +23,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 		+ "WHERE r.member_id = :memberId ", nativeQuery = true)
 	List<MemberReviewProjection> findReviewsByMemberId(@Param("memberId") Long memberId);
 
-	@Query("select count(r) from Review r where r.member.memberId = :memberId")
-	long countReviewByMemberId(@Param("memberId") Long memberId);
-
 	@Query(value = "SELECT "
 		+ "r.cafe_id "
 		+ "FROM review r "
 		+ "WHERE r.member_id = :memberId "
 		+ "AND r.created_time > DATE_SUB(NOW(), INTERVAL 1 DAY) ", nativeQuery = true)
 	List<Long> findCafeIdsOfRecentReviews(@Param("memberId") Long memberId);
+
+	@Query("select count(r) from Review r where r.member.memberId = :memberId")
+	long countReviewByMemberId(@Param("memberId") Long memberId);
+
+	@Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END FROM Review r WHERE r.cafe.cafeId = :cafeId")
+	Boolean existsReviewByCafeId(@Param("cafeId") Long cafeId);
 }

--- a/backend/src/main/java/com/cafein/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/cafein/backend/domain/review/service/ReviewService.java
@@ -57,4 +57,12 @@ public class ReviewService {
 			throw new BusinessException(ErrorCode.REVIEWED_CAFE_WITHIN_A_DAY);
 		}
 	}
+
+	@Transactional(readOnly = true)
+	public void validateReviewExists(final Long cafeId) {
+		log.info("hasReviewed = {}", reviewRepository.existsReviewByCafeId(cafeId));
+		if (!reviewRepository.existsReviewByCafeId(cafeId)) {
+			throw new BusinessException(ErrorCode.REVIEW_NOT_FOUND);
+		}
+	}
 }

--- a/backend/src/main/java/com/cafein/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/cafein/backend/global/config/SwaggerConfig.java
@@ -9,9 +9,12 @@ import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.builders.RequestParameterBuilder;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.ParameterType;
+import springfox.documentation.service.RequestParameter;
 import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
@@ -29,7 +32,19 @@ public class SwaggerConfig {
 			.build()
 			.apiInfo(apiInfo())			//API 문서에 대한 정보 추가
 			.securityContexts(Arrays.asList(securityContext()))
-			.securitySchemes(Arrays.asList(apikey()));
+			.securitySchemes(Arrays.asList(apikey()))
+			.globalRequestParameters(globalParameters());
+	}
+
+	private List<RequestParameter> globalParameters() {
+		return Arrays.asList(
+			new RequestParameterBuilder()
+				.in(ParameterType.HEADER)
+				.name("Authorization")
+				.description("HTTP Authorization Header")
+				.required(Boolean.TRUE)
+				.build()
+		);
 	}
 
 	private ApiInfo apiInfo() {

--- a/backend/src/main/java/com/cafein/backend/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/cafein/backend/global/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 
 	// 리뷰
 	REVIEWED_CAFE_WITHIN_A_DAY(HttpStatus.BAD_REQUEST, "R-001", "해당 카페에 대해 하루에 한번만 리뷰를 작성할 수 있습니다."),
+	REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "R-002", "해당 카페에는 리뷰가 존재하지 않아 혼잡도를 확인할 수 없습니다."),
 
 	// 댓글
 	KEYWORD_NOT_EXIST(HttpStatus.BAD_REQUEST,"CO-001","해당 키워드는 존재하지 않습니다."),

--- a/backend/src/test/java/com/cafein/backend/api/CafeControllerTest.java
+++ b/backend/src/test/java/com/cafein/backend/api/CafeControllerTest.java
@@ -18,7 +18,7 @@ class CafeControllerTest extends ControllerTestSupporter {
 	void 카페_정보를_조회한다() throws Exception {
 		given(cafeService.findCafeInfoById(anyLong(), eq(1L))).willReturn(CAFE_INFO_DTO);
 
-		mockMvc(new CafeController(memberService, cafeService, viewedCafeService))
+		mockMvc(new CafeController(memberService, cafeService, reviewService, viewedCafeService))
 			.perform(
 				get("/api/cafe/1")
 				.contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -32,7 +32,7 @@ class CafeControllerTest extends ControllerTestSupporter {
 	void 커피콩을_사용해서_카페_정보를_열람한다() throws Exception {
 		given(cafeService.findCafeInfoById(anyLong(), eq(1L))).willReturn(CAFE_INFO_DTO);
 
-		mockMvc(new CafeController(memberService, cafeService, viewedCafeService))
+		mockMvc(new CafeController(memberService, cafeService, reviewService, viewedCafeService))
 			.perform(
 				post("/api/cafe/1")
 				.contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/cafein/backend/api/CafeControllerTest.java
+++ b/backend/src/test/java/com/cafein/backend/api/CafeControllerTest.java
@@ -25,7 +25,7 @@ class CafeControllerTest extends ControllerTestSupporter {
 				.header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_ACCESS)
 			)
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.cafeInfoProjection.name").value("5to7"));
+			.andExpect(jsonPath("$.cafeInfo.name").value("5to7"));
 	}
 
 	@Test
@@ -39,7 +39,7 @@ class CafeControllerTest extends ControllerTestSupporter {
 				.header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_ACCESS)
 			)
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.cafeInfoProjection.name").value("5to7"));
+			.andExpect(jsonPath("$.cafeInfo.name").value("5to7"));
 
 		then(memberService).should(times(1)).subtractCoffeeBean(any());
 		then(viewedCafeService).should(times(1)).addViewedCafe(any(), any());

--- a/backend/src/test/java/com/cafein/backend/integration/CafeIntegrationTest.java
+++ b/backend/src/test/java/com/cafein/backend/integration/CafeIntegrationTest.java
@@ -23,14 +23,14 @@ class CafeIntegrationTest extends IntegrationSupporter {
 	void 커피콩을_사용하지_않아_혼잡도_조회_권한이_없는_카페_정보를_반환한다() {
 		final var response = get("/api/cafe/2", generateAccessHeader(access_token));
 
-		assertThat(response.jsonPath().getString("cafeInfoProjection.averageCongestion")).isEqualTo("0");
+		assertThat(response.jsonPath().getString("cafeInfo.averageCongestion")).isEqualTo("0");
 	}
 
 	@Test
 	void 커피콩을_사용해_이미_조회한_카페_정보를_반환한다() {
 		final var response = get("/api/cafe/3", generateAccessHeader(access_token));
 
-		assertThat(response.jsonPath().getString("cafeInfoProjection.averageCongestion")).isEqualTo("3");
+		assertThat(response.jsonPath().getString("cafeInfo.averageCongestion")).isEqualTo("3");
 	}
 
 	@Test

--- a/backend/src/test/java/com/cafein/backend/integration/CafeIntegrationTest.java
+++ b/backend/src/test/java/com/cafein/backend/integration/CafeIntegrationTest.java
@@ -55,4 +55,23 @@ class CafeIntegrationTest extends IntegrationSupporter {
 			() -> assertThat(response2.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value())
 		);
 	}
+
+	@Test
+	void 리뷰가_없는_카페는_리뷰의_존재_상태를_false로_반환한다() {
+		final var response = get("/api/cafe/4", generateAccessHeader(access_token));
+
+		assertThat(response.jsonPath().getString("cafeInfo.hasReviewed")).isEqualTo("false");
+	}
+
+	@Test
+	void 리뷰가_없는_카페의_혼잡도_조회_요청은_커피콩을_차감하지_않고_예외를_반환한다() {
+		final var response = post("/api/cafe/4", generateAccessHeader(access_token));
+
+		Assertions.assertAll(
+			() -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+			() -> assertThat(memberService.findMemberByMemberId(1L).getCoffeeBean()).isEqualTo(100),
+			() -> assertThat(response.jsonPath().getString("errorMessage"))
+				.isEqualTo("해당 카페에는 리뷰가 존재하지 않아 혼잡도를 확인할 수 없습니다.")
+		);
+	}
 }

--- a/backend/src/test/java/com/cafein/backend/integration/ReviewIntegrationTest.java
+++ b/backend/src/test/java/com/cafein/backend/integration/ReviewIntegrationTest.java
@@ -22,4 +22,15 @@ class ReviewIntegrationTest extends IntegrationSupporter {
 			() -> assertThat(memberService.findMemberByMemberId(1L).getCoffeeBean()).isEqualTo(102)
 		);
 	}
+
+	@Test
+	void 동일_카페에_대해_하루에_한_번만_리뷰를_등록_가능하다() {
+		final var response = post("/api/cafe/3/review", generateAccessHeader(access_token), REVIEW_REQUEST);
+
+		assertAll(
+			() -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+			() -> assertThat(response.body().jsonPath().getString("errorMessage"))
+				.isEqualTo("해당 카페에 대해 하루에 한번만 리뷰를 작성할 수 있습니다.")
+		);
+	}
 }


### PR DESCRIPTION
## 변경 내용
- 리뷰가 없을 때의 상태를 반영했습니다.
- 중복 리뷰가 불가능하도록(하루에 한 번만 리뷰 작성이 가능하도록) 검증하는 테스트 코드를 작성했습니다.
- JSON 직렬화 시 포맷을 설정했습니다.
- Swagger 전역 설정을 등록했습니다.
## 이슈 링크

#106 

## 변경된 동작
### 리뷰가 없을 때의 상태를 반영했습니다.
`CafeInfoProjection`의 `findCafeInfoById` 메서드에 서브쿼리로 리뷰가 있다면 `"true"`, 없다면 `"false"`로 반환합니다.
<img width="324" alt="스크린샷 2023-08-09 오후 3 55 15" src="https://github.com/TEAM-cafe-in/cafe-in-be/assets/98090620/18363855-e249-4b68-bcbf-fc606d75e4cd">

### 커피콩을 사용해서 카페 혼잡도를 조회할 때, 리뷰가 없다면 예외를 발생시키고 커피콩을 차감하지 않습니다.
해당 테스트 코드를 `CafeIntegrationTest`에 작성했습니다.

### 하루에 한 번만 리뷰 작성이 가능하도록 검증하는 테스트 코드를 작성했습니다.

### JSON 직렬화 시 `@JsonPropertyOrder`를 이용해서 직렬화 하는 속성의 순서를 정했습니다
<img width="309" alt="스크린샷 2023-08-09 오후 3 57 30" src="https://github.com/TEAM-cafe-in/cafe-in-be/assets/98090620/25ffc35b-15fc-43d2-a0bf-c493b9055e65">

### Swagger 전역 설정을 등록했습니다.
현재 모든 API 요청 시 `Authorization 헤더` 값이 필요하므로, Swagger 에 전역 설정으로 등록했습니다.
<img width="603" alt="스크린샷 2023-08-09 오후 3 59 48" src="https://github.com/TEAM-cafe-in/cafe-in-be/assets/98090620/d0e86fc5-304b-41ec-a25f-60c4422cfae9">
다음과 같이 나타납니다.

### 모든 테스트 코드는 이상 없이 통과합니다.
<img width="573" alt="스크린샷 2023-08-09 오후 3 48 27" src="https://github.com/TEAM-cafe-in/cafe-in-be/assets/98090620/e94aa54f-9441-4243-b09e-7c251bd76d69">

## 특이 사항
.
## 체크리스트

- [x] 코드가 모든 유닛 테스트를 통과했습니다.
- [x] 코드가 변경사항에 대한 새로운 유닛 테스트를 포함합니다.
- [x] 변경사항에 대한 문서가 업데이트 되었습니다.
